### PR TITLE
Texture formats, camera extraction

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -8,11 +8,9 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs,
     system::{Commands, Local, Query, Res, ResMut},
 };
-use bevy_image::BevyDefault;
 use bevy_light::Skybox;
 use bevy_math::Mat4;
 use bevy_render::{
-    camera::ExtractedCamera,
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     render_asset::RenderAssets,
     render_resource::{
@@ -22,7 +20,7 @@ use bevy_render::{
     renderer::RenderDevice,
     sync_world::RenderEntity,
     texture::GpuImage,
-    view::{Msaa, ViewTarget, ViewUniform, ViewUniforms},
+    view::{ExtractedView, Msaa, ViewUniform, ViewUniforms},
     Extract, ExtractSchedule, GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_shader::Shader;
@@ -131,7 +129,7 @@ fn init_skybox_pipeline(mut commands: Commands, asset_server: Res<AssetServer>) 
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
 struct SkyboxPipelineKey {
-    hdr: bool,
+    color_target_format: TextureFormat,
     samples: u32,
     depth_format: TextureFormat,
 }
@@ -171,11 +169,7 @@ impl SpecializedRenderPipeline for SkyboxPipeline {
             fragment: Some(FragmentState {
                 shader: self.shader.clone(),
                 targets: vec![Some(ColorTargetState {
-                    format: if key.hdr {
-                        ViewTarget::TEXTURE_FORMAT_HDR
-                    } else {
-                        TextureFormat::bevy_default()
-                    },
+                    format: key.color_target_format,
                     // BlendState::REPLACE is not needed here, and None will be potentially much faster in some cases.
                     blend: None,
                     write_mask: ColorWrites::ALL,
@@ -195,14 +189,14 @@ fn prepare_skybox_pipelines(
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<SkyboxPipeline>>,
     pipeline: Res<SkyboxPipeline>,
-    cameras: Query<(Entity, &ExtractedCamera, &Msaa), With<Skybox>>,
+    cameras: Query<(Entity, &ExtractedView, &Msaa), With<Skybox>>,
 ) {
-    for (entity, camera, msaa) in &cameras {
+    for (entity, view, msaa) in &cameras {
         let pipeline_id = pipelines.specialize(
             &pipeline_cache,
             &pipeline,
             SkyboxPipelineKey {
-                hdr: camera.hdr,
+                color_target_format: view.texture_format,
                 samples: msaa.samples(),
                 depth_format: CORE_3D_DEPTH_FORMAT,
             },

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -18,7 +18,6 @@ use bevy_core_pipeline::{
     tonemapping::{DebandDither, Tonemapping},
 };
 use bevy_ecs::prelude::*;
-use bevy_image::BevyDefault as _;
 use bevy_light::{EnvironmentMapLight, IrradianceVolume, ShadowFilteringMethod};
 use bevy_render::{
     camera::ExtractedCamera,
@@ -350,11 +349,7 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
                 shader: self.deferred_lighting_shader.clone(),
                 shader_defs,
                 targets: vec![Some(ColorTargetState {
-                    format: if key.contains(MeshPipelineKey::HDR) {
-                        ViewTarget::TEXTURE_FORMAT_HDR
-                    } else {
-                        TextureFormat::bevy_default()
-                    },
+                    format: key.main_pass_color_attachment_format(),
                     blend: None,
                     write_mask: ColorWrites::ALL,
                 })],
@@ -445,7 +440,7 @@ pub fn prepare_deferred_lighting_pipelines(
 ) {
     for (
         entity,
-        camera,
+        _camera,
         view,
         tonemapping,
         dither,
@@ -466,7 +461,11 @@ pub fn prepare_deferred_lighting_pipelines(
             continue;
         }
 
-        let mut view_key = MeshPipelineKey::from_hdr(camera.hdr);
+        let is_hdr = view.texture_format == ViewTarget::TEXTURE_FORMAT_HDR;
+        let mut view_key = MeshPipelineKey::from_hdr(is_hdr);
+        if !is_hdr {
+            view_key |= MeshPipelineKey::sdr_color_attachment_format_bits(view.texture_format);
+        }
 
         if normal_prepass {
             view_key |= MeshPipelineKey::NORMAL_PREPASS;
@@ -491,7 +490,7 @@ pub fn prepare_deferred_lighting_pipelines(
         // Always true, since we're in the deferred lighting pipeline
         view_key |= MeshPipelineKey::DEFERRED_PREPASS;
 
-        if !camera.hdr {
+        if !is_hdr {
             if let Some(tonemapping) = tonemapping {
                 view_key |= MeshPipelineKey::TONEMAP_IN_SHADER;
                 view_key |= match tonemapping {

--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -18,7 +18,11 @@ use bevy_mesh::VertexBufferLayout;
 use bevy_mesh::{Mesh, MeshVertexBufferLayout, MeshVertexBufferLayoutRef, MeshVertexBufferLayouts};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_render::erased_render_asset::ErasedRenderAssets;
-use bevy_render::{camera::TemporalJitter, render_resource::*, view::ExtractedView};
+use bevy_render::{
+    camera::TemporalJitter,
+    render_resource::*,
+    view::{ExtractedView, ViewTarget},
+};
 use bevy_utils::default;
 use core::any::{Any, TypeId};
 
@@ -78,8 +82,12 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass(
         has_irradiance_volumes,
     ) in &mut views
     {
+        let is_hdr = view.texture_format == ViewTarget::TEXTURE_FORMAT_HDR;
         let mut view_key =
-            MeshPipelineKey::from_msaa_samples(1) | MeshPipelineKey::from_hdr(view.hdr);
+            MeshPipelineKey::from_msaa_samples(1) | MeshPipelineKey::from_hdr(is_hdr);
+        if !is_hdr {
+            view_key |= MeshPipelineKey::sdr_color_attachment_format_bits(view.texture_format);
+        }
 
         if normal_prepass {
             view_key |= MeshPipelineKey::NORMAL_PREPASS;
@@ -126,7 +134,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass(
             }
         }
 
-        if !view.hdr {
+        if !is_hdr {
             if let Some(tonemapping) = tonemapping {
                 view_key |= MeshPipelineKey::TONEMAP_IN_SHADER;
                 view_key |= tonemapping_pipeline_key(*tonemapping);
@@ -294,8 +302,12 @@ pub fn prepare_material_meshlet_meshes_prepass(
         (normal_prepass, motion_vector_prepass, deferred_prepass),
     ) in &mut views
     {
+        let is_hdr = view.texture_format == ViewTarget::TEXTURE_FORMAT_HDR;
         let mut view_key =
-            MeshPipelineKey::from_msaa_samples(1) | MeshPipelineKey::from_hdr(view.hdr);
+            MeshPipelineKey::from_msaa_samples(1) | MeshPipelineKey::from_hdr(is_hdr);
+        if !is_hdr {
+            view_key |= MeshPipelineKey::sdr_color_attachment_format_bits(view.texture_format);
+        }
 
         if normal_prepass.is_some() {
             view_key |= MeshPipelineKey::NORMAL_PREPASS;

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -28,11 +28,12 @@ use bevy_ecs::{
     relationship::RelationshipSourceCollection,
     system::{lifetimeless::*, SystemParamItem},
 };
-use bevy_image::{BevyDefault, ImageSampler, TextureFormatPixelInfo};
+use bevy_image::{ImageSampler, TextureFormatPixelInfo};
 use bevy_light::{
     EnvironmentMapLight, IrradianceVolume, NotShadowCaster, NotShadowReceiver,
     ShadowFilteringMethod, TransmittedShadowReceiver,
 };
+use bevy_log::warn_once;
 use bevy_math::{Affine3, Affine3Ext, Rect, UVec2, Vec3, Vec4};
 use bevy_mesh::{
     skinning::SkinnedMesh, BaseMeshPipelineKey, Mesh, Mesh3d, MeshTag, MeshVertexBufferLayoutRef,
@@ -401,10 +402,12 @@ pub fn check_views_need_specialization(
         has_ssr,
     ) in views.iter_mut()
     {
-        // HACK: we should be specializing by texture format, not bool hdr, but mesh pipeline keys have limited space.
         let is_hdr = view.texture_format == ViewTarget::TEXTURE_FORMAT_HDR;
         let mut view_key =
             MeshPipelineKey::from_msaa_samples(msaa.samples()) | MeshPipelineKey::from_hdr(is_hdr);
+        if !is_hdr {
+            view_key |= MeshPipelineKey::sdr_color_attachment_format_bits(view.texture_format);
+        }
 
         if normal_prepass {
             view_key |= MeshPipelineKey::NORMAL_PREPASS;
@@ -3108,13 +3111,16 @@ bitflags::bitflags! {
         const SCREEN_SPACE_SPECULAR_TRANSMISSION_MEDIUM = 1 << Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_SHIFT_BITS;
         const SCREEN_SPACE_SPECULAR_TRANSMISSION_HIGH   = 2 << Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_SHIFT_BITS;
         const SCREEN_SPACE_SPECULAR_TRANSMISSION_ULTRA  = 3 << Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_SHIFT_BITS;
+        const SDR_COLOR_ATTACHMENT_FORMAT_RESERVED_BITS = Self::SDR_COLOR_ATTACHMENT_FORMAT_MASK_BITS
+            << Self::SDR_COLOR_ATTACHMENT_FORMAT_SHIFT_BITS;
         const ALL_RESERVED_BITS =
             Self::BLEND_RESERVED_BITS.bits() |
             Self::MSAA_RESERVED_BITS.bits() |
             Self::TONEMAP_METHOD_RESERVED_BITS.bits() |
             Self::SHADOW_FILTER_METHOD_RESERVED_BITS.bits() |
             Self::VIEW_PROJECTION_RESERVED_BITS.bits() |
-            Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_RESERVED_BITS.bits();
+            Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_RESERVED_BITS.bits() |
+            Self::SDR_COLOR_ATTACHMENT_FORMAT_RESERVED_BITS.bits();
     }
 }
 
@@ -3142,6 +3148,11 @@ impl MeshPipelineKey {
     const SCREEN_SPACE_SPECULAR_TRANSMISSION_SHIFT_BITS: u64 =
         Self::VIEW_PROJECTION_MASK_BITS.count_ones() as u64 + Self::VIEW_PROJECTION_SHIFT_BITS;
 
+    const SDR_COLOR_ATTACHMENT_FORMAT_MASK_BITS: u64 = 0b11;
+    const SDR_COLOR_ATTACHMENT_FORMAT_SHIFT_BITS: u64 =
+        Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_MASK_BITS.count_ones() as u64
+            + Self::SCREEN_SPACE_SPECULAR_TRANSMISSION_SHIFT_BITS;
+
     pub fn from_msaa_samples(msaa_samples: u32) -> Self {
         let msaa_bits =
             (msaa_samples.trailing_zeros() as u64 & Self::MSAA_MASK_BITS) << Self::MSAA_SHIFT_BITS;
@@ -3153,6 +3164,42 @@ impl MeshPipelineKey {
             MeshPipelineKey::HDR
         } else {
             MeshPipelineKey::NONE
+        }
+    }
+
+    /// Returns the bits for [`ExtractedView::texture_format`] for non-HDR views
+    pub fn sdr_color_attachment_format_bits(format: TextureFormat) -> Self {
+        let code: u64 = match format {
+            TextureFormat::Rgba8UnormSrgb => 0,
+            TextureFormat::Bgra8UnormSrgb => 1,
+            TextureFormat::Rgba8Unorm => 2,
+            _ => {
+                warn_once!(
+                    "Unknown main pass format {:?}, mesh pipeline uses Rgba8UnormSrgb",
+                    format
+                );
+                0
+            }
+        };
+        Self::from_bits_retain(
+            (code & Self::SDR_COLOR_ATTACHMENT_FORMAT_MASK_BITS)
+                << Self::SDR_COLOR_ATTACHMENT_FORMAT_SHIFT_BITS,
+        )
+    }
+
+    /// Color format of the main pass color attachment for this pipeline key.
+    pub fn main_pass_color_attachment_format(&self) -> TextureFormat {
+        if self.contains(MeshPipelineKey::HDR) {
+            ViewTarget::TEXTURE_FORMAT_HDR
+        } else {
+            let code = (self.bits() >> Self::SDR_COLOR_ATTACHMENT_FORMAT_SHIFT_BITS)
+                & Self::SDR_COLOR_ATTACHMENT_FORMAT_MASK_BITS;
+            match code {
+                0 => TextureFormat::Rgba8UnormSrgb,
+                1 => TextureFormat::Bgra8UnormSrgb,
+                2 => TextureFormat::Rgba8Unorm,
+                _ => TextureFormat::Rgba8UnormSrgb,
+            }
         }
     }
 
@@ -3611,11 +3658,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
             }
         }
 
-        let format = if key.contains(MeshPipelineKey::HDR) {
-            ViewTarget::TEXTURE_FORMAT_HDR
-        } else {
-            TextureFormat::bevy_default()
-        };
+        let format = key.main_pass_color_attachment_format();
 
         // This is defined here so that custom shaders that use something other than
         // the mesh binding from bevy_pbr::mesh_bindings can easily make use of this

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -12,7 +12,7 @@ use crate::{
     view::{
         ColorGrading, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing,
         RenderExtractedVisibleEntities, RenderVisibleEntities, RenderVisibleEntitiesClass,
-        RetainedViewEntity, ViewUniformOffset, VisibilityExtractionSystemParam,
+        RetainedViewEntity, ViewTarget, ViewUniformOffset, VisibilityExtractionSystemParam,
     },
     Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
 };
@@ -53,6 +53,10 @@ use bevy_window::{PrimaryWindow, Window, WindowCreated, WindowResized, WindowSca
 use itertools::Either;
 use wgpu::TextureFormat;
 
+/// Main-pass color [`TextureFormat`] keyed by camera render entity.
+#[derive(Resource, Default, Deref, DerefMut)]
+pub struct CameraMainPassTextureFormats(pub HashMap<Entity, TextureFormat>);
+
 #[derive(Default)]
 pub struct CameraPlugin;
 
@@ -80,6 +84,7 @@ impl Plugin for CameraPlugin {
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
+                .init_resource::<CameraMainPassTextureFormats>()
                 .init_resource::<SortedCameras>()
                 .init_resource::<DirtySpecializations>()
                 .init_resource::<DirtyWireframeSpecializations>()
@@ -462,6 +467,7 @@ pub struct ExtractedCamera {
 
 pub fn extract_cameras(
     mut commands: Commands,
+    mut main_pass_formats: ResMut<CameraMainPassTextureFormats>,
     query: Extract<
         Query<(
             Entity,
@@ -496,6 +502,7 @@ pub fn extract_cameras(
     gpu_preprocessing_support: Res<GpuPreprocessingSupport>,
     visibility_extraction_system_param: VisibilityExtractionSystemParam,
 ) {
+    main_pass_formats.clear();
     let primary_window = primary_window.iter().next();
     type ExtractedCameraComponents = (
         ExtractedCamera,
@@ -590,7 +597,7 @@ pub fn extract_cameras(
             // removed from it.
 
             let target = render_target.normalize(primary_window);
-            let texture_format = target
+            let output_texture_format = target
                 .as_ref()
                 .and_then(|target| {
                     target.get_texture_view_format(
@@ -600,6 +607,14 @@ pub fn extract_cameras(
                     )
                 })
                 .unwrap_or(TextureFormat::bevy_default());
+            let texture_format = if hdr {
+                ViewTarget::TEXTURE_FORMAT_HDR
+            } else if compositing_space.is_some_and(|s| *s == CompositingSpace::Srgb) {
+                TextureFormat::Rgba8Unorm
+            } else {
+                output_texture_format
+            };
+            main_pass_formats.insert(render_entity, texture_format);
 
             let mut commands = commands.entity(render_entity);
             commands.insert((

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -23,9 +23,7 @@ use bevy_camera::visibility::InheritedVisibility;
 use bevy_camera::{Camera, Camera2d, Camera3d, RenderTarget};
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
-use bevy_render::camera::NormalizedRenderTargetExt;
-use bevy_render::texture::ManualTextureViews;
-use bevy_render::view::ExtractedWindows;
+use bevy_render::camera::{extract_cameras, CameraMainPassTextureFormats};
 use bevy_shader::load_shader_library;
 use bevy_sprite_render::SpriteAssetEvents;
 use bevy_ui::widget::{ImageNode, TextScroll, TextShadow, ViewportNode};
@@ -58,7 +56,6 @@ use bevy_render::{
     Extract, ExtractSchedule, GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_sprite::BorderRect;
-use bevy_window::PrimaryWindow;
 #[cfg(feature = "bevy_ui_debug")]
 pub use debug_overlay::{GlobalUiDebugOptions, UiDebugOptions};
 
@@ -238,7 +235,9 @@ impl Plugin for UiRenderPlugin {
             .add_systems(
                 ExtractSchedule,
                 (
-                    extract_ui_camera_view.in_set(RenderUiSystems::ExtractCameraViews),
+                    extract_ui_camera_view
+                        .after(extract_cameras)
+                        .in_set(RenderUiSystems::ExtractCameraViews),
                     extract_uinode_background_colors.in_set(RenderUiSystems::ExtractBackgrounds),
                     extract_uinode_images.in_set(RenderUiSystems::ExtractImages),
                     extract_uinode_borders.in_set(RenderUiSystems::ExtractBorders),
@@ -747,24 +746,18 @@ pub fn extract_ui_camera_view(
                 Entity,
                 RenderEntity,
                 &Camera,
-                &RenderTarget,
                 Option<&UiAntiAlias>,
                 Option<&BoxShadowSamples>,
             ),
             Or<(With<Camera2d>, With<Camera3d>)>,
         >,
     >,
-    primary_window: Extract<Query<Entity, With<PrimaryWindow>>>,
-    extracted_windows: Res<ExtractedWindows>,
-    manual_texture_views: Res<ManualTextureViews>,
-    images: Res<RenderAssets<GpuImage>>,
+    main_pass_formats: Res<CameraMainPassTextureFormats>,
     mut live_entities: Local<HashSet<RetainedViewEntity>>,
 ) {
-    let primary_window = primary_window.iter().next();
     live_entities.clear();
 
-    for (main_entity, render_entity, camera, render_target, ui_anti_alias, shadow_samples) in &query
-    {
+    for (main_entity, render_entity, camera, ui_anti_alias, shadow_samples) in &query {
         // ignore inactive cameras
         if !camera.is_active {
             commands
@@ -774,7 +767,21 @@ pub fn extract_ui_camera_view(
             continue;
         }
 
-        if let Some(physical_viewport_rect) = camera.physical_viewport_rect() {
+        if let (Some(physical_viewport_rect), Some(_viewport_size), Some(target_size)) = (
+            camera.physical_viewport_rect(),
+            camera.physical_viewport_size(),
+            camera.physical_target_size(),
+        ) && target_size.x != 0
+            && target_size.y != 0
+        {
+            let Some(texture_format) = main_pass_formats.get(&render_entity).copied() else {
+                commands
+                    .get_entity(render_entity)
+                    .expect("Camera entity wasn't synced.")
+                    .remove::<(UiCameraView, UiAntiAlias, BoxShadowSamples)>();
+                continue;
+            };
+
             // use a projection matrix with the origin in the top left instead of the bottom left that comes with OrthographicProjection
             let projection_matrix = Mat4::orthographic_rh(
                 0.0,
@@ -788,18 +795,6 @@ pub fn extract_ui_camera_view(
             // main 3D or 2D camera, which will have subview index 0.
             let retained_view_entity =
                 RetainedViewEntity::new(main_entity.into(), None, UI_CAMERA_SUBVIEW);
-
-            let target = render_target.normalize(primary_window);
-            let texture_format = target
-                .as_ref()
-                .and_then(|target| {
-                    target.get_texture_view_format(
-                        &extracted_windows,
-                        &images,
-                        &manual_texture_views,
-                    )
-                })
-                .unwrap_or(TextureFormat::bevy_default());
 
             // Creates the UI view.
             let ui_camera_view = commands


### PR DESCRIPTION
## Objective

- Fix 3D scenes, 2D bloom, and compositing space cases where main pass `TextureFormat` disagreed between `ExtractedView`, UI subviews, and specialized pipelines.

## Solution

- Resolve `ExtractedView::texture_format` in `extract_cameras`
- add `CameraMainPassTextureFormats` map camera render entity to texture format, name kinda long.
- that map is filled in `extract_cameras` so `extract_ui_camera_view` can read it same extract pass
- for 3d pipeline the fragment color targets follow view `texture_format`, not `TextureFormat::bevy_default()` for all SDR views.
- `prepare_view_targets` keeps using `view.texture_format` for GPU main textures.